### PR TITLE
added lohgout logic and modify get user

### DIFF
--- a/src/main/java/com/example/loan_origination_system/controller/UserController.java
+++ b/src/main/java/com/example/loan_origination_system/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.example.loan_origination_system.controller;
+
+import com.example.loan_origination_system.model.people.User;
+import com.example.loan_origination_system.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    /**
+     * GET /api/users/me
+     * Returns the currently logged-in user's details based on their JWT token.
+     * Frontend must send: Authorization: Bearer <token>
+     */
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser() {
+        try {
+            // JwtFilter already decoded the token and stored the username in SecurityContext
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication == null || !authentication.isAuthenticated()) {
+                return ResponseEntity.status(401).body("Unauthorized: No valid token provided");
+            }
+            String username = authentication.getName();
+            User user = userService.getUserByUsername(username);
+            return ResponseEntity.ok(user);
+        } catch (Exception e) {
+            return ResponseEntity.status(401).body("Unauthorized: " + e.getMessage());
+        }
+    }
+}
+
+

--- a/src/main/java/com/example/loan_origination_system/security/TokenBlacklist.java
+++ b/src/main/java/com/example/loan_origination_system/security/TokenBlacklist.java
@@ -1,0 +1,34 @@
+package com.example.loan_origination_system.security;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory blacklist for invalidated JWT tokens.
+ * Tokens are stored until their natural expiration date, then auto-cleaned.
+ */
+@Component
+public class TokenBlacklist {
+
+    // Map of token -> expiration time
+    private final Map<String, Date> blacklistedTokens = new ConcurrentHashMap<>();
+
+    public void blacklist(String token, Date expiration) {
+        blacklistedTokens.put(token, expiration);
+        cleanExpired(); // Clean up old entries while we're here
+    }
+
+    public boolean isBlacklisted(String token) {
+        return blacklistedTokens.containsKey(token);
+    }
+
+    // Remove tokens that have already expired (they are useless to keep)
+    private void cleanExpired() {
+        Date now = new Date();
+        blacklistedTokens.entrySet().removeIf(entry -> entry.getValue().before(now));
+    }
+}
+

--- a/src/main/java/com/example/loan_origination_system/service/UserService.java
+++ b/src/main/java/com/example/loan_origination_system/service/UserService.java
@@ -167,6 +167,17 @@ public class UserService {
     }
 
     /**
+     * GET by Username (used for /me endpoint)
+     */
+    public User getUserByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(
+                        "USER_NOT_FOUND",
+                        "User not found with username: " + username
+                ));
+    }
+
+    /**
      * FULL UPDATE (PUT)
      */
     @Transactional


### PR DESCRIPTION
This pull request adds user logout functionality with JWT invalidation and introduces a new endpoint to fetch the currently authenticated user's details. It implements a token blacklist to prevent reuse of logged-out tokens, updates the authentication filter to respect blacklisted tokens, and adds a new controller for user profile retrieval.

**Authentication and Security Enhancements:**

* Added a `TokenBlacklist` component for in-memory storage of invalidated JWT tokens, with automatic cleanup of expired tokens. (`TokenBlacklist.java`)
* Updated `AuthController` to include a `/logout` endpoint that blacklists the user's JWT token and clears the security context. (`AuthController.java`) [[1]](diffhunk://#diff-850953506b3891b656a8d4182b097401f686659d225791d960c55ff817dce1d6R7-R9) [[2]](diffhunk://#diff-850953506b3891b656a8d4182b097401f686659d225791d960c55ff817dce1d6R35-R37) [[3]](diffhunk://#diff-850953506b3891b656a8d4182b097401f686659d225791d960c55ff817dce1d6R60-R72)
* Modified `JwtFilter` to check incoming tokens against the blacklist and reject requests with invalidated tokens, returning a 401 Unauthorized response. (`JwtFilter.java`) [[1]](diffhunk://#diff-bf8afab2c0ca5de9e16b5cd5f40a8f6ca2282a6f7c615a2af52dcf5ee2b1e228L23-R28) [[2]](diffhunk://#diff-bf8afab2c0ca5de9e16b5cd5f40a8f6ca2282a6f7c615a2af52dcf5ee2b1e228R38-R45)

**User Profile Endpoint:**

* Added a new `UserController` with a `/api/users/me` endpoint to return the authenticated user's details, leveraging the security context to identify the user. (`UserController.java`)
* Extended `UserService` with a `getUserByUsername` method to support user lookup by username for the `/me` endpoint. (`UserService.java`)