### PR TITLE
Put every route back to secured

### DIFF
--- a/src/main/java/com/example/loan_origination_system/controller/UserController.java
+++ b/src/main/java/com/example/loan_origination_system/controller/UserController.java
@@ -22,7 +22,6 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<?> getCurrentUser() {
         try {
-            // JwtFilter already decoded the token and stored the username in SecurityContext
             var authentication = SecurityContextHolder.getContext().getAuthentication();
             if (authentication == null || !authentication.isAuthenticated()) {
                 return ResponseEntity.status(401).body("Unauthorized: No valid token provided");

--- a/src/main/java/com/example/loan_origination_system/security/SecurityConfig.java
+++ b/src/main/java/com/example/loan_origination_system/security/SecurityConfig.java
@@ -29,23 +29,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // 1. Disable CSRF (Cross-Site Request Forgery) because we are using tokens, not cookies
                 .csrf(AbstractHttpConfigurer::disable)
 
-                // 2. Configure endpoint access
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll() // Allow health/info checks
-                        .requestMatchers("/api/auth/**","/api/**").permitAll() // Anyone can try to login
+                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/api/auth/login","/api/auth/logout").permitAll()
                         .anyRequest().authenticated() // EVERY other endpoint requires a valid JWT
                 )
 
-                // 3. Make the application stateless (No HTTP sessions)
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                // 4. Wire up our custom user details and password encoder
                 .authenticationProvider(authenticationProvider())
-
-                // 5. Put our custom Gatekeeper BEFORE the standard Spring Security gatekeeper
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();


### PR DESCRIPTION
This pull request makes targeted security improvements to the authentication and authorization flow in the application. The most significant change is tightening access control by restricting which endpoints are publicly accessible, ensuring that only login and logout endpoints are open to unauthenticated users, while all other API endpoints now require authentication.

**Security and Access Control Improvements:**

* Updated the `SecurityConfig` class to only permit unauthenticated access to `/api/auth/login` and `/api/auth/logout` endpoints, instead of all `/api/**` endpoints, enhancing security by requiring authentication for all other API routes.

**Code Cleanliness:**

* Removed outdated or redundant inline comments in both `UserController` and `SecurityConfig` for improved code clarity and maintainability. [[1]](diffhunk://#diff-0d548379ae13823d14eaad9ab3603f22bcb5470af2e339e1bed16dab32070f0fL25) [[2]](diffhunk://#diff-2a3938d2394a9178bcf57137a3c12dc25e7f1a56dfd21204e8e00b64655794a8L32-L48)